### PR TITLE
Add support for stream key to secure rtmp endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,23 @@ If you want prism to listen on a different port than the default 1935, call it
 with the `--bind` flag:
 
     prism --bind :1337 ...
+
+By default prism will generate a key to protect the rtmp endpoint.  If you want to prevent it from being generated you can use flag:
+
+    prism --no-key
+
+If you would like to provide your own key to protect the rtmp endpoint you can use flag:
+
+    prism --key="MySuperAwesomeKey"
+
+When you start prism you will see something like:
+
+    RTMP stream key set to: f977bc5a-21f6-44e7-869e-00807430480b
+    Starting RTMP server...
+    Waiting for incoming connection...
+
+To begin broadcasting point OBS or your tool of choice to:
+
+    rtmp://your-host:1935/live/publish/f977bc5a-21f6-44e7-869e-00807430480b
+
+Replace host and key with your own. Actual path can be what ever you want so long as key is at the end.

--- a/main.go
+++ b/main.go
@@ -148,10 +148,8 @@ func main() {
 	}
 
 	server.HandlePublish = func(conn *rtmp.Conn) {
-		connectingKey := strings.ReplaceAll(conn.URL.Path, "/", "")
-
-		if connectingKey != *streamKey {
-			fmt.Println("Connection attempt made using incorrect key: ", connectingKey)
+		if !strings.HasSuffix(conn.URL.Path, *streamKey) {
+			fmt.Println("Connection attempt made using incorrect key: ", conn.URL.Path)
 			conn.Close()
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -149,7 +149,7 @@ func main() {
 
 	server.HandlePublish = func(conn *rtmp.Conn) {
 		if !strings.HasSuffix(conn.URL.Path, *streamKey) {
-			fmt.Println("Connection attempt made using incorrect key: ", conn.URL.Path)
+			fmt.Println("Connection attempt made using incorrect key:", conn.URL.Path)
 			conn.Close()
 			return
 		}


### PR DESCRIPTION
Not sure how you feel about using uuid there.  But its a function I have sitting around in my scratch that is nice for uuid so dropped it in to generate a default key.